### PR TITLE
Fixed tablespaces error in mysqldump command.

### DIFF
--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -10,7 +10,7 @@ export MYSQL_PWD="$DB_PASSWORD"
 CURRENT_TIMESTAMP=$(date +%Y-%m-%dT%TZ)
 BACKUP_FILENAME="${CURRENT_TIMESTAMP}.gzip"
 echo "DEBUG: Dumping database ${DB_NAME} into ${BACKUP_FILENAME} as a single transaction..."
-mysqldump -u "${DB_USER}" --host "${DB_HOST}" --single-transaction=TRUE "${DB_NAME}" | gzip -9 > "${BACKUP_FILENAME}"
+mysqldump -u "${DB_USER}" --host "${DB_HOST}" --single-transaction=TRUE --no-tablespaces "${DB_NAME}" | gzip -9 > "${BACKUP_FILENAME}"
 echo "DEBUG: Done"
 
 BACKUP_S3_PATH="${DB_BACKUPS_S3_FOLDER}${BACKUP_FILENAME}"


### PR DESCRIPTION
Errors in logs:
https://one.eu.newrelic.com/launcher/logger.log-launcher?platform[accountId]=2244219&platform[timeRange][duration]=21600000&launcher=eyJxdWVyeSI6Im15c3FsZHVtcCBFcnJvciIsImJlZ2luIjpudWxsLCJlbmQiOm51bGwsImlzRW50aXRsZWQiOnRydWUsImF0dHJzIjpbInRpbWVzdGFtcCIsIm5hbWVzcGFjZV9uYW1lIiwibGFiZWxzLnJlbGVhc2UiLCJsYWJlbHMuY29tcG9uZW50IiwibWVzc2FnZSJdLCJhY3RpdmVWaWV3IjoiVmlldyBBbGwgTG9ncyIsImV2ZW50VHlwZXMiOlsiTG9nIl19&pane=eyJuZXJkbGV0SWQiOiJsb2dnZXIuaG9tZSIsImFjY291bnRJZCI6MjI0NDIxOSwiJHNka1ZlcnNpb24iOjN9&state=c65a121b-0d9e-a2eb-d099-442a50a40adb

About the fix: https://dba.stackexchange.com/questions/271981/access-denied-you-need-at-least-one-of-the-process-privileges-for-this-ope